### PR TITLE
fixed bodygaurd

### DIFF
--- a/src/jokers.lua
+++ b/src/jokers.lua
@@ -593,7 +593,9 @@ SMODS.Joker
         if G.jokers and not context.blueprint then
             for i = 1, #G.jokers.cards do
                 if context.selling_self and G.jokers.cards[i] == card then
-                    G.jokers.cards[i+1]:set_eternal(true)
+					if G.jokers.cards[i+1] ~= nil then
+                    	G.jokers.cards[i+1]:set_eternal(true)
+					end
                 end
             end
         end


### PR DESCRIPTION
original bodygaurd code had no checks to see if the joker to the right existed. If there was no joker to the right then selling the bodygaurd would crash the game with a NULL pointer exception.