### PR TITLE
Accidently included the mirror fix before it was complete

### DIFF
--- a/src/jokers.lua
+++ b/src/jokers.lua
@@ -230,11 +230,6 @@ SMODS.Joker
                         SMODS.debuff_card(vampire, false, "j_willatro_silvermirror")
                     end
                 end
-				if context.selling_self and not context.blueprint then
-					if vampire.perishable == false and vampire.debuffed == true then
-						SMODS.debuff_card(vampire, false, "j_willatro_silvermirror")
-                	end
-        		end
             end
         end
 


### PR DESCRIPTION
Just realized my main branch had this in it. Sorry for the confusion.
I notice that mirror didn't remove the vampire debuff when you sell it so was attempting to fix that issue. My solution is not currently working and will cause issues when attempting to sell the mirror joker.